### PR TITLE
Use a static message for tags

### DIFF
--- a/.woodpecker/build-cpp-qt.yaml
+++ b/.woodpecker/build-cpp-qt.yaml
@@ -47,7 +47,7 @@ steps:
     environment: *environment
     commands:
       - cd libre-graph-api-cpp-qt-client
-      - git tag -a ${CI_COMMIT_TAG} -m "${CI_COMMIT_MESSAGE}"
+      - git tag -a ${CI_COMMIT_TAG} -m "release $CI_COMMIT_TAG"
     when:
       - event: tag
   push_target_repo:

--- a/.woodpecker/build-go.yaml
+++ b/.woodpecker/build-go.yaml
@@ -47,7 +47,7 @@ steps:
     environment: *environment
     commands:
       - cd libre-graph-api-go
-      - git tag -a ${CI_COMMIT_TAG} -m "${CI_COMMIT_MESSAGE}"
+      - git tag -a ${CI_COMMIT_TAG} -m "release $CI_COMMIT_TAG"
     when:
       - event: tag
   push_target_repo:

--- a/.woodpecker/build-php.yaml
+++ b/.woodpecker/build-php.yaml
@@ -47,7 +47,7 @@ steps:
     environment: *environment
     commands:
       - cd libre-graph-api-php
-      - git tag -a ${CI_COMMIT_TAG} -m "${CI_COMMIT_MESSAGE}"
+      - git tag -a ${CI_COMMIT_TAG} -m "release $CI_COMMIT_TAG"
     when:
       - event: tag
   push_target_repo:

--- a/.woodpecker/build-typescript-axios.yaml
+++ b/.woodpecker/build-typescript-axios.yaml
@@ -47,7 +47,7 @@ steps:
     environment: *environment
     commands:
       - cd libre-graph-api-typescript-axios
-      - git tag -a ${CI_COMMIT_TAG} -m "${CI_COMMIT_MESSAGE}"
+      - git tag -a ${CI_COMMIT_TAG} -m "release $CI_COMMIT_TAG"
     when:
       - event: tag
   push_target_repo:


### PR DESCRIPTION
There was still a quoting issue with ${CI_COMMIT_MESSAGE}. And it did only contain the generic "Merge pull request XYZ" message anyway. Let's just use "release $tag" as the commit message.