### PR TITLE
feat: Add open extensions for DriveItems

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -1207,18 +1207,7 @@ paths:
           example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
           x-ms-docs-key-type: item
         - $ref: '#/components/parameters/driveItemSelect'
-        - name: $expand
-          in: query
-          description: Expand related entities
-          style: form
-          explode: false
-          schema:
-            uniqueItems: true
-            type: array
-            items:
-              enum:
-                - extensions
-              type: string
+        - $ref: '#/components/parameters/driveItemExpand'
       responses:
         "200":
           description: Retrieved driveItem
@@ -6280,6 +6269,19 @@ components:
         request download url:
           value:
             - '@microsoft.graph.downloadUrl'
+    driveItemExpand:
+      name: $expand
+      in: query
+      description: Expand related entities
+      style: form
+      explode: false
+      schema:
+        uniqueItems: true
+        type: array
+        items:
+          enum:
+            - extensions
+          type: string
     drivesFilter:
       name: $filter
       in: query

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -2086,6 +2086,227 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/v1beta1/drives/{drive-id}/items/{item-id}/extensions':
+    get:
+      tags:
+        - driveItem.extensions
+      summary: List all extensions on a DriveItem
+      operationId: ListExtensions
+      description: |
+        Get the collection of open extensions on the specified DriveItem.
+
+        Each extension is identified by its `extensionName`, which follows a reverse DNS naming convention
+        (e.g. `com.example.myApp`).
+      parameters:
+        - name: drive-id
+          in: path
+          description: "key: id of drive"
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: "key: id of item"
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
+          x-ms-docs-key-type: item
+      responses:
+        "200":
+          description: Retrieved extensions
+          content:
+            application/json:
+              schema:
+                title: Collection of openTypeExtensions
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/openTypeExtension'
+              examples:
+                list extensions:
+                  value:
+                    value:
+                      - extensionName: "com.example.project"
+                        status: "reviewed"
+                        assignee: "alice"
+                      - extensionName: "eu.opencloud.workflow"
+                        step: "approval"
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/v1beta1/drives/{drive-id}/items/{item-id}/extensions/{extensionName}':
+    get:
+      tags:
+        - driveItem.extensions
+      summary: Get an extension by name
+      operationId: GetExtension
+      description: |
+        Get a specific open extension identified by the extension name.
+      parameters:
+        - name: drive-id
+          in: path
+          description: "key: id of drive"
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: "key: id of item"
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
+          x-ms-docs-key-type: item
+        - name: extensionName
+          in: path
+          description: "The unique name of the extension, using reverse DNS notation (e.g. com.example.myApp)"
+          required: true
+          schema:
+            type: string
+          example: com.example.project
+      responses:
+        "200":
+          description: Retrieved extension
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/openTypeExtension'
+              examples:
+                get extension:
+                  value:
+                    extensionName: "com.example.project"
+                    status: "reviewed"
+                    assignee: "alice"
+                    priority: 3
+        "404":
+          description: Extension not found
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    put:
+      tags:
+        - driveItem.extensions
+      summary: Create or update an extension
+      operationId: UpsertExtension
+      description: |
+        Create or update an open extension on the specified DriveItem.
+
+        If the extension does not exist, it is created. If it already exists, the provided properties
+        are merged with the existing data:
+
+        * Properties included in the request body are added or updated.
+        * Properties set to `null` are removed from the extension.
+        * Properties not included in the request body remain unchanged.
+
+        The extension name should follow reverse DNS naming conventions (e.g. `com.example.myApp`)
+        to avoid collisions between applications.
+      parameters:
+        - name: drive-id
+          in: path
+          description: "key: id of drive"
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: "key: id of item"
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
+          x-ms-docs-key-type: item
+        - name: extensionName
+          in: path
+          description: "The unique name of the extension, using reverse DNS notation (e.g. com.example.myApp)"
+          required: true
+          schema:
+            type: string
+          example: com.example.project
+      requestBody:
+        description: Extension properties to set. Use `null` values to remove individual properties.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/openTypeExtensionUpdate'
+            examples:
+              create extension:
+                value:
+                  status: "reviewed"
+                  assignee: "alice"
+                  priority: 3
+              update single property:
+                value:
+                  status: "approved"
+              remove a property:
+                value:
+                  priority: null
+      responses:
+        "200":
+          description: Extension updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/openTypeExtension'
+        "201":
+          description: Extension created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/openTypeExtension'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+    delete:
+      tags:
+        - driveItem.extensions
+      summary: Delete an extension
+      operationId: DeleteExtension
+      description: |
+        Delete an open extension from the specified DriveItem.
+
+        This removes the extension and all its properties.
+      parameters:
+        - name: drive-id
+          in: path
+          description: "key: id of drive"
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: "key: id of item"
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
+          x-ms-docs-key-type: item
+        - name: extensionName
+          in: path
+          description: "The unique name of the extension, using reverse DNS notation (e.g. com.example.myApp)"
+          required: true
+          schema:
+            type: string
+          example: com.example.project
+      responses:
+        "204":
+          description: Extension deleted
+        "404":
+          description: Extension not found
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   '/v1.0/drives/{drive-id}/root':
     get:
       tags:
@@ -4990,6 +5211,12 @@ components:
         '@UI.Hidden':
           description: Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true. Users can set this to hide permissions.
           type: boolean
+        extensions:
+          description: The collection of open extensions defined for this DriveItem. Nullable. Returned only on `$expand`.
+          type: array
+          items:
+            $ref: '#/components/schemas/openTypeExtension'
+          readOnly: true
     sharingLinkType:
       type: string
       enum: [ internal, view, upload, edit, createOnly, blocksDownload ]
@@ -5556,6 +5783,40 @@ components:
         password:
           type: string
           description: Password. It may require a password policy.
+    openTypeExtension:
+      type: object
+      description: |
+        Represents an open extension on a DriveItem, providing a flexible way to attach
+        untyped custom data to a resource.
+
+        Extensions are identified by their `extensionName`, which should follow reverse DNS
+        naming conventions (e.g. `com.example.myApp`) to avoid collisions between applications.
+      properties:
+        extensionName:
+          type: string
+          description: |
+            The unique identifier of the extension. Use reverse DNS naming conventions
+            (e.g. `com.example.myApp`).
+          readOnly: true
+      additionalProperties: true
+      example:
+        extensionName: "com.example.project"
+        status: "reviewed"
+        assignee: "alice"
+        priority: 3
+    openTypeExtensionUpdate:
+      type: object
+      description: |
+        Properties to set or remove on an open extension.
+
+        * Properties included in the request body are added or updated.
+        * Properties set to `null` are removed from the extension.
+        * Properties not included in the request body remain unchanged.
+      additionalProperties:
+        nullable: true
+      example:
+        status: "approved"
+        priority: null
     audio:
       type: object
       description: |

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -1207,6 +1207,18 @@ paths:
           example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
           x-ms-docs-key-type: item
         - $ref: '#/components/parameters/driveItemSelect'
+        - name: $expand
+          in: query
+          description: Expand related entities
+          style: form
+          explode: false
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              enum:
+                - extensions
+              type: string
       responses:
         "200":
           description: Retrieved driveItem
@@ -2186,7 +2198,7 @@ paths:
                     assignee: "alice"
                     priority: 3
         "404":
-          description: Extension not found
+          $ref: '#/components/responses/error'
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -2232,7 +2244,11 @@ paths:
             type: string
           example: com.example.project
       requestBody:
-        description: Extension properties to set. Use `null` values to remove individual properties.
+        description: |
+          Extension properties to set. Use `null` values to remove individual properties.
+
+          The `extensionName` is derived from the URL path parameter and must not be included
+          in the request body. If present, it will be ignored.
         required: true
         content:
           application/json:
@@ -2303,7 +2319,7 @@ paths:
         "204":
           description: Extension deleted
         "404":
-          description: Extension not found
+          $ref: '#/components/responses/error'
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -2127,7 +2127,7 @@ paths:
           example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
           x-ms-docs-key-type: item
       responses:
-        "200":
+        '200':
           description: Retrieved extensions
           content:
             application/json:
@@ -2151,7 +2151,7 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
-  '/v1beta1/drives/{drive-id}/items/{item-id}/extensions/{extensionName}':
+  '/v1beta1/drives/{drive-id}/items/{item-id}/extensions/{extension-name}':
     get:
       tags:
         - driveItem.extensions
@@ -2176,7 +2176,7 @@ paths:
             type: string
           example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
           x-ms-docs-key-type: item
-        - name: extensionName
+        - name: extension-name
           in: path
           description: "The unique name of the extension, using reverse DNS notation (e.g. com.example.myApp)"
           required: true
@@ -2184,7 +2184,7 @@ paths:
             type: string
           example: com.example.project
       responses:
-        "200":
+        '200':
           description: Retrieved extension
           content:
             application/json:
@@ -2197,7 +2197,7 @@ paths:
                     status: "reviewed"
                     assignee: "alice"
                     priority: 3
-        "404":
+        '404':
           $ref: '#/components/responses/error'
         default:
           $ref: '#/components/responses/error'
@@ -2236,7 +2236,7 @@ paths:
             type: string
           example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
           x-ms-docs-key-type: item
-        - name: extensionName
+        - name: extension-name
           in: path
           description: "The unique name of the extension, using reverse DNS notation (e.g. com.example.myApp)"
           required: true
@@ -2267,13 +2267,13 @@ paths:
                 value:
                   priority: null
       responses:
-        "200":
+        '200':
           description: Extension updated
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/openTypeExtension'
-        "201":
+        '201':
           description: Extension created
           content:
             application/json:
@@ -2308,7 +2308,7 @@ paths:
             type: string
           example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
           x-ms-docs-key-type: item
-        - name: extensionName
+        - name: extension-name
           in: path
           description: "The unique name of the extension, using reverse DNS notation (e.g. com.example.myApp)"
           required: true
@@ -2316,9 +2316,9 @@ paths:
             type: string
           example: com.example.project
       responses:
-        "204":
+        '204':
           description: Extension deleted
-        "404":
+        '404':
           $ref: '#/components/responses/error'
         default:
           $ref: '#/components/responses/error'
@@ -5807,6 +5807,8 @@ components:
 
         Extensions are identified by their `extensionName`, which should follow reverse DNS
         naming conventions (e.g. `com.example.myApp`) to avoid collisions between applications.
+      required:
+        - extensionName
       properties:
         extensionName:
           type: string


### PR DESCRIPTION
## Summary

Add API endpoints for open extensions on DriveItems, enabling applications to attach arbitrary custom metadata to files and folders via the Libre Graph API.

## Motivation

Currently, there is no way to attach application-specific metadata to DriveItems through the Libre Graph API. While OpenCloud's WebDAV layer supports arbitrary properties via PROPPATCH/PROPFIND, this functionality is not exposed through the Graph API. This means applications that use the Graph API cannot store and retrieve custom metadata on files.

Open extensions close this gap. They provide a simple, schema-less mechanism for any application to store key-value data on a DriveItem, identified by a unique extension name.

## Use case

Avoid small extension services having to introduce their own shadow metadata storage that needs to be kept in sync with the storage/index in OpenCloud. 
I wouldn't do it in the first iteration, but in the long run the data could potentially be indexed by the search service as well. Needs more thought and planning. 

## API design

### Endpoints

Four new endpoints under `v1beta1`:

| Method | Path | Operation | Description |
|--------|------|-----------|-------------|
| `GET` | `.../items/{item-id}/extensions` | ListExtensions | List all extensions on a DriveItem |
| `GET` | `.../items/{item-id}/extensions/{extensionName}` | GetExtension | Get a specific extension |
| `PUT` | `.../items/{item-id}/extensions/{extensionName}` | UpsertExtension | Create or update an extension (merge semantics) |
| `DELETE` | `.../items/{item-id}/extensions/{extensionName}` | DeleteExtension | Delete an entire extension |

### DriveItem schema extension

The `driveItem` schema gains an `extensions` property (array of `openTypeExtension`), returned only when the client requests `$expand=extensions`.

### Schemas

- **`openTypeExtension`**: Object with a read-only `extensionName` and `additionalProperties: true` for the free-form data.
- **`openTypeExtensionUpdate`**: Object with `additionalProperties: { nullable: true }` to allow `null` values for property deletion.

### Example flow

**Create/set properties:**
```http
PUT /v1beta1/drives/{drive-id}/items/{item-id}/extensions/com.example.project
Content-Type: application/json

{
  "status": "reviewed",
  "assignee": "alice",
  "priority": 3
}
```
 `201 Created`

**Update a single property (merge):**
```http
PUT /v1beta1/drives/{drive-id}/items/{item-id}/extensions/com.example.project
Content-Type: application/json

{
  "status": "approved"
}
```
’ `200 OK`.  `assignee` and `priority` remain unchanged.

**Remove a property:**
```http
PUT /v1beta1/drives/{drive-id}/items/{item-id}/extensions/com.example.project
Content-Type: application/json

{
  "priority": null
}
```
 `200 OK`  `priority` is removed, other properties remain.

**Read:**
```http
GET /v1beta1/drives/{drive-id}/items/{item-id}/extensions/com.example.project
```
```json
{
  "extensionName": "com.example.project",
  "status": "approved",
  "assignee": "alice"
}
```

**Delete entire extension:**
```http
DELETE /v1beta1/drives/{drive-id}/items/{item-id}/extensions/com.example.project
```
â†’ `204 No Content`

## Design considerations

### PUT with upsert instead of POST + PATCH

Microsoft Graph uses `POST` to create and `PATCH` to update extensions, requiring the client to know whether the extension already exists. This separation makes sense when the server generates the resource identifier, but extension names are client-chosen (reverse DNS convention). Since the client determines the target URI, `PUT` is the semantically correct HTTP method.

This is consistent with existing Libre Graph API patterns: profile photos use `PUT` with upsert semantics (`UpsertProfilePhoto`), and tags use `PUT` for assignment (`AssignTags`). Neither uses the POST-to-create / PATCH-to-update split.

### Merge semantics on PUT

For DriveItems specifically, Microsoft Graph's beta API uses merge semantics on PATCH: properties not included in the request body remain unchanged, and properties set to `null` are removed. We adopt the same behavior on PUT:

- **Omitted properties** remain unchanged (merge)
- **Properties set to `null`** removed from the extension
- **`DELETE` on the extension** removes the extension and all its properties

Note: Microsoft's documentation for open extensions is internally contradictory on this point - for directory objects it describes replace semantics, for other resources (including DriveItems) it describes merge semantics. We follow the DriveItem-specific behavior.

### Naming convention

Extension names should use reverse DNS notation (e.g. `com.example.myApp`) to avoid collisions between applications. This matches the Microsoft Graph convention for `extensionName`.

## Relation to Microsoft Graph API

Microsoft Graph supports [open extensions on DriveItems](https://learn.microsoft.com/en-us/graph/api/resources/opentypeextension?view=graph-rest-beta) only in its **beta API** it is not available in v1.0. In practice, [developers report](https://learn.microsoft.com/en-us/answers/questions/2260418/adding-and-fetching-custom-metadata-for-onedrive) that the DriveItem support is unreliable, and Microsoft recommends using SharePoint listItem fields as a workaround instead.

This means there is no stable MS Graph API to be compatible with. We are free to design the cleanest API for this use case. The key differences from MS Graph beta:

| Aspect | MS Graph (beta) | Libre Graph |
|--------|-----------------|-------------|
| Create | `POST .../extensions` | `PUT .../extensions/{name}` (upsert) |
| Update | `PATCH .../extensions/{name}` | `PUT .../extensions/{name}` (upsert) |
| Update semantics | Merge (for non-directory resources) | Merge |
| Delete property | Set to `null` | Set to `null` |
| DriveItem support | Beta only, unreliable | First-class support |

## Planned implementation

### Storage mapping

The implementation can build directly on OpenCloud's existing `ArbitraryMetadata` infrastructure in the CS3/reva layer no storage-layer changes are required.

Each extension maps to a set of `ArbitraryMetadata` keys using a fixed namespace prefix:

```
Extension:  com.example.project
Property:   status = "reviewed"

ArbitraryMetadata key:   http://opencloud.eu/ns/extensions/com.example.project/status
ArbitraryMetadata value: "reviewed"
```

The Graph service handler translates between the JSON representation and the flat key-value pairs:

- **PUT** calls `SetArbitraryMetadata` for all non-null properties, `UnsetArbitraryMetadata` for null properties
- **GET** calls `GetMD` with the extension's key prefix, strips the prefix, groups by extension name, returns as JSON
- **DELETE** calls `UnsetArbitraryMetadata` for all keys matching the extension's prefix
- **`$expand=extensions`** requests all keys with the `http://opencloud.eu/ns/extensions/` prefix, groups them into extension objects

### Cross-protocol access via WebDAV

Because the extension data is stored as standard `ArbitraryMetadata` with a well-defined key format, it is automatically accessible via WebDAV without any additional implementation:

```
Extension name:  com.example.project
WebDAV namespace: http://opencloud.eu/ns/extensions/com.example.project
```

A WebDAV PROPFIND requesting properties in this namespace will return the extension data. A PROPPATCH setting properties in this namespace will update it. This means applications can read and write the same metadata through both protocols interchangeably.

### Scope of implementation

The implementation requires:

1. **New routes** in the Graph service (`services/graph/pkg/service/v0/service.go`)
2. **New handler functions** for List, Get, Upsert, Delete (new file, e.g. `api_driveitem_extensions.go`)
3. **Extend the DriveItem conversion** in `driveitems.go` to populate the `extensions` field when `$expand=extensions` is requested
4. **No changes** to the storage layer, decomposedfs, reva, or the WebDAV handler

### Future work (out of scope)

- **Search/filter by extension properties**: Would require indexing extension data in the Bleve search index. Not needed for v1.
- **Schema validation**: Optional typed extensions (similar to MS Graph's schema extensions). Not needed for v1.
- **Drive-wide extension listing**: "Which extension names exist across all items in this drive?" Requires index support.

Of course I'm willing to implement this. 