### PR TITLE
feat: add @libre.graph.motionPhoto facet to driveItem

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4914,6 +4914,9 @@ components:
         video:
           description: Video metadata, if the item is a video. Read-only.
           $ref: '#/components/schemas/video'
+        '@libre.graph.motionPhoto':
+          description: Motion Photo metadata, if the item is a Motion Photo. Read-only.
+          $ref: '#/components/schemas/motionPhoto'
         '@client.synchronize':
           description: Indicates if the item is synchronized with the underlying storage provider. Read-only.
           type: boolean
@@ -5137,39 +5140,38 @@ components:
           type: string
           format: date-time
           description: Represents the date and time the photo was taken. Read-only.
-        '@libre.graph.motionPhoto':
+    motionPhoto:
+      type: object
+      readOnly: true
+      description: |
+        Motion Photo metadata. A Motion Photo is a still image with a short video clip appended to
+        the end of the file. The presence of this facet on a driveItem indicates that the item is
+        a Motion Photo; absence indicates it is not.
+
+        Based on the Google Motion Photo format v1.0 specification:
+        https://developer.android.com/media/platform/motion-photo-format
+      properties:
+        version:
           type: integer
           format: int32
+          description: The file format version of the Motion Photo. Currently always 1. Read-only.
           readOnly: true
-          description: |
-            Indicates whether the file is a Motion Photo (a still image with an embedded video clip).
-            1 means the file should be treated as a Motion Photo, 0 or absent means it should not.
-            Based on Camera:MotionPhoto from the Google Motion Photo format specification.
-            https://developer.android.com/media/platform/motion-photo-format
-        '@libre.graph.motionPhotoVersion':
-          type: integer
-          format: int32
-          readOnly: true
-          description: |
-            The file format version of the Motion Photo. Currently always 1.
-            Based on Camera:MotionPhotoVersion from the Google Motion Photo format specification.
-        '@libre.graph.motionPhotoPresentationTimestampUs':
+        presentationTimestampUs:
           type: integer
           format: int64
-          readOnly: true
           description: |
-            Presentation timestamp in microseconds of the video frame that corresponds to the still image.
-            A value of -1 indicates unspecified. If absent, readers should use a timestamp near the
-            middle of the video track.
-            Based on Camera:MotionPhotoPresentationTimestampUs from the Google Motion Photo format specification.
-        '@libre.graph.motionPhotoVideoSize':
+            Presentation timestamp in microseconds of the video frame that corresponds to the still
+            image. A value of -1 indicates unspecified. If absent, readers should use a timestamp
+            near the middle of the video track. Read-only.
+          readOnly: true
+        videoSize:
           type: integer
           format: int64
-          readOnly: true
           description: |
-            Size in bytes of the embedded video portion of the Motion Photo.
-            Clients can use this together with the file size to construct a Range request
-            that fetches only the video part: Range: bytes=<fileSize - motionPhotoVideoSize>-
+            Size in bytes of the embedded video portion of the file. The video is appended at the
+            end of the file, so clients can fetch it with a Range request:
+            `Range: bytes=<fileSize - videoSize>-`. Read-only.
+          readOnly: true
     geoCoordinates:
       type: object
       readOnly: true

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5137,6 +5137,31 @@ components:
           type: string
           format: date-time
           description: Represents the date and time the photo was taken. Read-only.
+        '@libre.graph.motionPhoto':
+          type: integer
+          format: int32
+          readOnly: true
+          description: |
+            Indicates whether the file is a Motion Photo (a still image with an embedded video clip).
+            1 means the file should be treated as a Motion Photo, 0 or absent means it should not.
+            Based on Camera:MotionPhoto from the Google Motion Photo format specification.
+            https://developer.android.com/media/platform/motion-photo-format
+        '@libre.graph.motionPhotoVersion':
+          type: integer
+          format: int32
+          readOnly: true
+          description: |
+            The file format version of the Motion Photo. Currently always 1.
+            Based on Camera:MotionPhotoVersion from the Google Motion Photo format specification.
+        '@libre.graph.motionPhotoPresentationTimestampUs':
+          type: integer
+          format: int64
+          readOnly: true
+          description: |
+            Presentation timestamp in microseconds of the video frame that corresponds to the still image.
+            A value of -1 indicates unspecified. If absent, readers should use a timestamp near the
+            middle of the video track.
+            Based on Camera:MotionPhotoPresentationTimestampUs from the Google Motion Photo format specification.
     geoCoordinates:
       type: object
       readOnly: true

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5162,6 +5162,14 @@ components:
             A value of -1 indicates unspecified. If absent, readers should use a timestamp near the
             middle of the video track.
             Based on Camera:MotionPhotoPresentationTimestampUs from the Google Motion Photo format specification.
+        '@libre.graph.motionPhotoVideoSize':
+          type: integer
+          format: int64
+          readOnly: true
+          description: |
+            Size in bytes of the embedded video portion of the Motion Photo.
+            Clients can use this together with the file size to construct a Range request
+            that fetches only the video part: Range: bytes=<fileSize - motionPhotoVideoSize>-
     geoCoordinates:
       type: object
       readOnly: true


### PR DESCRIPTION
# Description

## What are Motion Photos?

Motion Photos are image files (JPEG, HEIC, or AVIF) with a short video clip (typically 1.5-3 seconds) appended to the end of the file. When you take a photo on a Google Pixel or Samsung Galaxy device, by default the camera captures a brief video around the moment of the shutter press and embeds it directly into the image file. The result is a single file that works as a normal photo everywhere, but can also play back the embedded video in apps that support it - similar to Apple's Live Photos, but as a single file rather than a separate image/video pair.

The format is specified by Google as the [Motion Photo format v1.0](https://developer.android.com/media/platform/motion-photo-format). It uses XMP metadata in the `Camera` namespace (`http://ns.google.com/photos/1.0/camera/`) to signal that a file is a Motion Photo and to describe how the still image and video relate to each other.

Samsung devices have converged on the same XMP metadata format, making this the de facto standard across the majority of Android devices.

## What this PR adds

Three new read-only properties on the `photo` schema, following the `@libre.graph.*` extension pattern for properties not present in the MS Graph API:

| Property | Type | Description |
|---|---|---|
| `@libre.graph.motionPhoto` | `integer` (int32) | `1` if the file is a Motion Photo, `0` or absent if not. Maps to `Camera:MotionPhoto` in the spec. |
| `@libre.graph.motionPhotoVersion` | `integer` (int32) | Format version of the Motion Photo spec (currently always `1`). Maps to `Camera:MotionPhotoVersion`. |
| `@libre.graph.motionPhotoPresentationTimestampUs` | `integer` (int64) | Presentation timestamp (in microseconds) of the video frame corresponding to the still image. `-1` means unspecified. Maps to `Camera:MotionPhotoPresentationTimestampUs`. |

## Example response

```json
{
  "photo": {
    "cameraMake": "Google",
    "cameraModel": "Pixel 8 Pro",
    "iso": 58,
    "takenDateTime": "2024-03-15T14:22:07Z",
    "@libre.graph.motionPhoto": 1,
    "@libre.graph.motionPhotoVersion": 1,
    "@libre.graph.motionPhotoPresentationTimestampUs": 1245580
  }
}
```

## Implementation plan

The overall goal is to let the OpenCloud web frontend detect Motion Photos and play back the embedded video when a user opens one.

### Backend (opencloud repo)

**Search service / Tika extractor** (`services/search/pkg/content/tika.go`):
- Tika already parses XMP metadata from JPEGs. The `Camera:MotionPhoto`, `Camera:MotionPhotoVersion`, and `Camera:MotionPhotoPresentationTimestampUs` fields should be available in the Tika metadata map.
- Extend the existing `getPhoto()` function to also read these fields and set them on the `Photo` struct.
- Also handle the legacy `GCamera:MicroVideo` format (Pixel 2/3 era) and Samsung's `EmbeddedVideoType: MotionPhoto_Data` by normalizing them to `motionPhoto = 1`.
- `marshalToStringMap` needs to strip the `@libre.graph.` prefix from JSON tag names before building the storage key, so that `@libre.graph.motionPhoto` is stored as `libre.graph.photo.motionPhoto`, not `libre.graph.photo.@libre.graph.motionPhoto`.

**Graph service** (`services/graph/pkg/service/v0/driveitems.go`):
- `unmarshalStringMap` needs the same prefix-stripping when looking up keys in the metadata map. Once that is in place and the `libre-graph-api-go` model is regenerated, the new fields flow through automatically via the existing reflection-based marshalling.

**Reva** (`internal/http/services/owncloud/ocdav/propfind/propfind.go`):
- Add `motionPhoto`, `motionPhotoVersion`, and `motionPhotoPresentationTimestampUs` to the `photoKeys` slice.
- `appendMetadataProp` already builds storage keys from the key list, so no further changes needed there beyond the new entries.

### Frontend (web repo)

**Preview app** (`packages/web-app-preview/`):
- When the preview app opens an image, check if `photo['@libre.graph.motionPhoto'] === 1`.
- If so, show a visual indicator (e.g. a "Motion" badge or play icon).
- On user interaction (hover, long-press, or play button), fetch the original file (not the thumbnail), extract the embedded MP4 by scanning for the `ftyp` signature in the bytes, and play it in a `<video>` element.

### Out of scope for now

- **Apple Live Photos**: These consist of two separate files (HEIC + MOV) linked by a `ContentIdentifier`. Supporting them requires a fundamentally different approach (file relationship management) and is tracked separately.
- **Video metadata extraction**: The embedded video's dimensions, duration, and codec are not available from the XMP metadata. Extracting them would require parsing the MP4 container separately. This information is not essential - the frontend learns it when it plays the video.
- **Backend video extraction endpoint**: A dedicated endpoint to stream just the video portion of a Motion Photo would avoid loading the full file on the client. This is a potential future optimization.

## References

- [Google Motion Photo format v1.0 specification](https://developer.android.com/media/platform/motion-photo-format)
- [Google MicroVideo (legacy) format details](https://timojyrinki.gitlab.io/hugo/post/2021-03-30-pixel-motionphoto-microvideo-file-formats/)


I'm willing to do the implementation