### PR TITLE
feat: Add @microsoft.graph.downloadUrl annotation and /content endpoi…

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5987,10 +5987,7 @@ components:
     driveItemSelect:
       name: $select
       in: query
-      description: |
-        Select properties to be returned. By default all properties are returned, except for
-        instance annotations (prefixed with `@`) that are computationally expensive or
-        short-lived. Instance annotations must be explicitly requested via `$select`.
+      description: Select additional properties to be returned.
       style: form
       explode: false
       schema:

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -1324,8 +1324,9 @@ paths:
         URL for the file. This is the same URL that is returned via the
         `@microsoft.graph.downloadUrl` instance annotation on the driveItem when
         requested via `$select`. Choose between the two based on whether you
-        want the server to follow the redirect for you (`/content`) or you want
-        to inspect / schedule / prefetch the URL yourself (annotation).
+        want to call the redirecting `/content` endpoint directly (for example,
+        with a client that follows redirects automatically) or you want to
+        inspect / schedule / prefetch the URL yourself via the annotation.
 
         The pre-authenticated URL is short-lived and does not require an
         `Authorization` header.
@@ -5999,7 +6000,8 @@ components:
           type: string
       examples:
         request download url:
-          value: '@microsoft.graph.downloadUrl'
+          value:
+            - '@microsoft.graph.downloadUrl'
     drivesFilter:
       name: $filter
       in: query

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -1354,8 +1354,10 @@ paths:
           description: Pre-authenticated redirect to the file content.
           headers:
             Location:
+              required: true
               schema:
                 type: string
+                format: uri
               description: The pre-authenticated URL where the content can be downloaded.
         '404':
           description: The driveItem was not found or is not a file.

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -1206,6 +1206,7 @@ paths:
             type: string
           example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
           x-ms-docs-key-type: item
+        - $ref: '#/components/parameters/driveItemSelect'
       responses:
         "200":
           description: Retrieved driveItem
@@ -1306,6 +1307,61 @@ paths:
       responses:
         '204':
           description: Success
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
+  '/v1beta1/drives/{drive-id}/items/{item-id}/content':
+    get:
+      tags:
+        - driveItem
+      summary: Download the content of a DriveItem
+      operationId: GetDriveItemContent
+      description: |
+        Download the contents of the primary stream (file) of a driveItem. Only
+        driveItem objects with a `file` facet can be downloaded.
+
+        The response is a `302 Found` redirecting to a pre-authenticated download
+        URL for the file. This is the same URL that is returned via the
+        `@microsoft.graph.downloadUrl` instance annotation on the driveItem when
+        requested via `$select`. Choose between the two based on whether you
+        want the server to follow the redirect for you (`/content`) or you want
+        to inspect / schedule / prefetch the URL yourself (annotation).
+
+        The pre-authenticated URL is short-lived and does not require an
+        `Authorization` header.
+
+        To download a partial range of bytes, apply the `Range` header to the
+        redirect target (the pre-authenticated URL), not to the `/content`
+        request.
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: 'key: id of item'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: item
+      responses:
+        '302':
+          description: Pre-authenticated redirect to the file content.
+          headers:
+            Location:
+              schema:
+                type: string
+              description: The pre-authenticated URL where the content can be downloaded.
+        '404':
+          description: The driveItem was not found or is not a file.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/odata.error'
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
@@ -4917,6 +4973,16 @@ components:
         '@client.synchronize':
           description: Indicates if the item is synchronized with the underlying storage provider. Read-only.
           type: boolean
+        '@microsoft.graph.downloadUrl':
+          description: |
+            A pre-authenticated URL that can be used to download the item's content without
+            providing an Authorization header. The URL is short-lived and cannot be cached.
+
+            This annotation is only populated when explicitly requested via `$select`, and
+            only for items that have a `file` facet. The returned URL is valid for a
+            limited time and should be used promptly.
+          type: string
+          readOnly: true
         # follows the SAP UI vocabulary: https://github.com/SAP/odata-vocabularies/blob/main/vocabularies/UI.md
         '@UI.Hidden':
           description: Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true. Users can set this to hide permissions.
@@ -5915,6 +5981,25 @@ components:
       description: Search items by search phrases
       schema:
         type: string
+    driveItemSelect:
+      name: $select
+      in: query
+      description: |
+        Select properties to be returned. By default all properties are returned, except for
+        instance annotations (prefixed with `@`) that are computationally expensive or
+        short-lived. Instance annotations must be explicitly requested via `$select`.
+      style: form
+      explode: false
+      schema:
+        uniqueItems: true
+        type: array
+        items:
+          enum:
+            - '@microsoft.graph.downloadUrl'
+          type: string
+      examples:
+        request download url:
+          value: '@microsoft.graph.downloadUrl'
     drivesFilter:
       name: $filter
       in: query


### PR DESCRIPTION
## Problem

The libre-graph-api spec currently provides no way to create signed links for a `driveItem`. Clients that need file content and can't send auth headers for the download have to leave Graph and fall back to:

- WebDAV `PROPFIND` with the `oc:downloadURL` property, or
- The legacy OCS client-side URL signing flow via `/ocs/v1.php/cloud/user/signing-key`, which is [[planned for removal in opencloud](https://github.com/opencloud-eu/opencloud/issues/1197)](https://github.com/opencloud-eu/opencloud/issues/1197)

This forces every Graph-consuming client that ever needs to generate a signed url for a file to switch protocol to WebDAV. 

## Proposal

Mirror the Microsoft Graph API's two-pronged approach:

1. **`@microsoft.graph.downloadUrl` instance annotation on `driveItem`**, opt-in via `$select`, for clients that want to obtain the URL without following a redirect (useful for prefetching, scheduling, or inspecting the URL).

2. **`GET /v1beta1/drives/{drive-id}/items/{item-id}/content`** returning `302 Found` redirecting to the same pre-authenticated URL, for clients that just want to download and are happy to follow redirects.

Both mechanisms return the same short-lived URL. The annotation is opt-in because computing the URL requires a signing operation; clients shouldn't pay that cost when they only wanted metadata.

We can use the regular dav endpoint as content for downloadUrl and as redirect target for /content. 

## What's in this PR

Three additions to `api/openapi-spec/v1.0.yaml`:

1. **Schema:** Adds `@microsoft.graph.downloadUrl` as an optional `string` property on the `driveItem` schema, alongside the existing `@client.synchronize` and `@UI.Hidden` annotations.

2. **Parameter component:** Adds a new `driveItemSelect` component (following the `drivesSelect` / `permissionsSelect` pattern) with an `enum` listing `@microsoft.graph.downloadUrl`.

3. **Endpoints:**
   - Attaches `$select` to the existing `GetDriveItem` operation.
   - Adds a new `GetDriveItemContent` operation at `/v1beta1/drives/{drive-id}/items/{item-id}/content` returning `302`.
   - Should be added to /children endpoints, but they are missing from spec. Different scope

## Design decisions (happy to revisit)

**Name:** `@microsoft.graph.downloadUrl`, matching MS Graph exactly. Alternative would be `@libre.graph.downloadUrl`, which would be more consistent with existing project-specific annotations like `@libre.graph.hasTrashedItems` and `@libre.graph.quickLink`. I went with the MS-compatible name. Happy to switch to `@libre.graph.downloadUrl` if you take a different stance on this. 

**Opt-in via `$select`:** Mirrors the WebDAV `PROPFIND` pattern, where `oc:downloadURL` is only returned when explicitly requested. Signing is cheap but non-zero, and the resulting URL is short-lived garbage if unused.

**302 redirect on `/content`:** Matches MS Graph. We can just use the existing endpoint in WebDAV.

## Open questions for the implementation side (not in this PR)

These are for the corresponding opencloud implementation, but worth flagging here since they affect the contract:

1. **TTL.** WebDAV `PROPFIND`'s `downloadURL` hardcodes 30 minutes in Reva ([[propfind.go:1770](https://github.com/opencloud-eu/reva/blob/main/internal/http/services/owncloud/ocdav/propfind/propfind.go#L1770)](https://github.com/opencloud-eu/reva/blob/main/internal/http/services/owncloud/ocdav/propfind/propfind.go#L1770)). MS Graph documents its equivalent as "a few minutes to 1 hour". The implementation should probably share a constant (or config) across both code paths for predictable behavior.

2. **Public shares.** WebDAV's `downloadURL` has a separate signing path for public-share contexts (`PublicShare.Signature`). 

I'm willing to take care of the implementation. 