### PR TITLE
feat: add @libre.graph.permissions.actions.allowedValues to driveItem

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -6291,10 +6291,7 @@ components:
     driveItemSelect:
       name: $select
       in: query
-      description: |
-        Select properties to be returned. By default all properties are returned, except for
-        instance annotations (prefixed with `@`) that are computationally expensive or
-        short-lived. Instance annotations must be explicitly requested via `$select`.
+      description: Instance annotations to include in the response.
       style: form
       explode: false
       schema:

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5196,9 +5196,6 @@ components:
             that support it. Mirrors the annotation of the same name on the
             `/permissions` endpoint, allowing clients to learn a caller's
             effective actions on an item without a separate round-trip.
-
-            See the `/permissions` endpoint for the mapping between CS3
-            `ResourcePermissions` and libre.graph actions.
           items:
             type: string
           readOnly: true

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -6291,7 +6291,7 @@ components:
     driveItemSelect:
       name: $select
       in: query
-      description: Instance annotations to include in the response.
+      description: Select additional properties to be returned.
       style: form
       explode: false
       schema:

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -2223,6 +2223,7 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: drive
+        - $ref: '#/components/parameters/driveItemSelect'
       responses:
         '200':
           description: Retrieved resource
@@ -2607,6 +2608,8 @@ paths:
         - me.drive.root
       summary: Get root from personal space
       operationId: HomeGetRoot
+      parameters:
+        - $ref: '#/components/parameters/driveItemSelect'
       responses:
         '200':
           description: Retrieved resource
@@ -2623,6 +2626,8 @@ paths:
         - me.drive.root.children
       summary: Get children from drive
       operationId: HomeGetChildren
+      parameters:
+        - $ref: '#/components/parameters/driveItemSelect'
       responses:
         '200':
           description: Retrieved resource list

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5187,6 +5187,21 @@ components:
           items:
             type: string
           readOnly: true
+        '@libre.graph.permissions.actions.allowedValues':
+          type: array
+          description: |
+            A list of actions the caller is allowed to perform on this item.
+
+            Only returned when explicitly requested via `$select` on endpoints
+            that support it. Mirrors the annotation of the same name on the
+            `/permissions` endpoint, allowing clients to learn a caller's
+            effective actions on an item without a separate round-trip.
+
+            See the `/permissions` endpoint for the mapping between CS3
+            `ResourcePermissions` and libre.graph actions.
+          items:
+            type: string
+          readOnly: true
     sharingLinkType:
       type: string
       enum: [ internal, view, upload, edit, createOnly, blocksDownload ]
@@ -6279,7 +6294,10 @@ components:
     driveItemSelect:
       name: $select
       in: query
-      description: Select additional properties to be returned.
+      description: |
+        Select properties to be returned. By default all properties are returned, except for
+        instance annotations (prefixed with `@`) that are computationally expensive or
+        short-lived. Instance annotations must be explicitly requested via `$select`.
       style: form
       explode: false
       schema:
@@ -6288,11 +6306,15 @@ components:
         items:
           enum:
             - '@microsoft.graph.downloadUrl'
+            - '@libre.graph.permissions.actions.allowedValues'
           type: string
       examples:
         request download url:
           value:
             - '@microsoft.graph.downloadUrl'
+        request allowed actions:
+          value:
+            - '@libre.graph.permissions.actions.allowedValues'
     drivesFilter:
       name: $filter
       in: query

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4999,9 +4999,6 @@ components:
             that support it. Mirrors the annotation of the same name on the
             `/permissions` endpoint, allowing clients to learn a caller's
             effective actions on an item without a separate round-trip.
-
-            See the `/permissions` endpoint for the mapping between CS3
-            `ResourcePermissions` and libre.graph actions.
           items:
             type: string
           readOnly: true

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4990,6 +4990,21 @@ components:
         '@UI.Hidden':
           description: Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true. Users can set this to hide permissions.
           type: boolean
+        '@libre.graph.permissions.actions.allowedValues':
+          type: array
+          description: |
+            A list of actions the caller is allowed to perform on this item.
+
+            Only returned when explicitly requested via `$select` on endpoints
+            that support it. Mirrors the annotation of the same name on the
+            `/permissions` endpoint, allowing clients to learn a caller's
+            effective actions on an item without a separate round-trip.
+
+            See the `/permissions` endpoint for the mapping between CS3
+            `ResourcePermissions` and libre.graph actions.
+          items:
+            type: string
+          readOnly: true
     sharingLinkType:
       type: string
       enum: [ internal, view, upload, edit, createOnly, blocksDownload ]
@@ -5987,7 +6002,10 @@ components:
     driveItemSelect:
       name: $select
       in: query
-      description: Select additional properties to be returned.
+      description: |
+        Select properties to be returned. By default all properties are returned, except for
+        instance annotations (prefixed with `@`) that are computationally expensive or
+        short-lived. Instance annotations must be explicitly requested via `$select`.
       style: form
       explode: false
       schema:
@@ -5996,11 +6014,15 @@ components:
         items:
           enum:
             - '@microsoft.graph.downloadUrl'
+            - '@libre.graph.permissions.actions.allowedValues'
           type: string
       examples:
         request download url:
           value:
             - '@microsoft.graph.downloadUrl'
+        request allowed actions:
+          value:
+            - '@libre.graph.permissions.actions.allowedValues'
     drivesFilter:
       name: $filter
       in: query

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -2100,6 +2100,7 @@ paths:
           schema:
             type: string
           x-ms-docs-key-type: drive
+        - $ref: '#/components/parameters/driveItemSelect'
       responses:
         '200':
           description: Retrieved resource
@@ -2430,6 +2431,8 @@ paths:
         - me.drive.root
       summary: Get root from personal space
       operationId: HomeGetRoot
+      parameters:
+        - $ref: '#/components/parameters/driveItemSelect'
       responses:
         '200':
           description: Retrieved resource
@@ -2446,6 +2449,8 @@ paths:
         - me.drive.root.children
       summary: Get children from drive
       operationId: HomeGetChildren
+      parameters:
+        - $ref: '#/components/parameters/driveItemSelect'
       responses:
         '200':
           description: Retrieved resource list

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5999,7 +5999,7 @@ components:
     driveItemSelect:
       name: $select
       in: query
-      description: Instance annotations to include in the response.
+      description: Select additional properties to be returned.
       style: form
       explode: false
       schema:

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5999,10 +5999,7 @@ components:
     driveItemSelect:
       name: $select
       in: query
-      description: |
-        Select properties to be returned. By default all properties are returned, except for
-        instance annotations (prefixed with `@`) that are computationally expensive or
-        short-lived. Instance annotations must be explicitly requested via `$select`.
+      description: Instance annotations to include in the response.
       style: form
       explode: false
       schema:


### PR DESCRIPTION
## Summary

Adds an optional, `$select`-gated instance annotation on `driveItem` that carries the list of libre.graph actions the caller is allowed to perform on an item. Mirrors the annotation of the same name on the `/permissions` endpoint so clients can get the effective-actions view inline without a separate round-trip per item.

Motivated by the discussion on #34 (search endpoint) — a sharing dialog rendered over search / listing results shouldn't need to fan out one `/permissions` call per hit just to know what the caller can do with each result.

## Changes

- Adds `@libre.graph.permissions.actions.allowedValues` to the `driveItem` schema, read-only, populated only when explicitly requested via `$select`.
- Extends the `driveItemSelect` component parameter (introduced by #38) with the new enum value and a matching example.
- Wires `driveItemSelect` to every endpoint that returns a `driveItem` directly: `GetDriveItem`, `GetRoot`, `HomeGetRoot`, `HomeGetChildren`.

Only **actions**, not **roles**, for now — roles are a curated bundle concept primarily useful for building a sharing-role picker and can be added in a follow-up if needed. Actions carry the full-fidelity permission info, equivalent (at finer granularity) to the WebDAV short-string we already produce today in search results.

## Notes on scope

- **Share-listing endpoints (`ListSharedByMe`, `ListSharedWithMe`) are intentionally skipped.** Their descriptions already promise that the `permissions` relation is always returned inline, so the opt-in `allowedValues` annotation would be redundant there.
- **`$select` semantics here are narrower than OData's.** The enum is constrained to specific opt-in instance annotations, and selecting a value *adds* it to the default response rather than restricting the response to only the selected fields. This matches the pattern established by #38's `driveItemSelect` and the existing `permissionsSelect` parameter on `/permissions`. Spec consistency within libre-graph-api wins over strict OData fidelity for this case.
- **Not on `remoteItem`.** The outer `driveItem` is sufficient for the common sharedWithMe case because the mountpoint stat already carries the caller's effective permissions on the underlying resource. If that assumption breaks we can add it to `remoteItem` in a follow-up.