### PR TITLE
fix(spec): add GET drives/{drive-id}/items/{item-id}/children

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -2110,6 +2110,60 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/v1.0/drives/{drive-id}/items/{item-id}/children':
+    get:
+      tags:
+        - driveItem
+      summary: List children of a DriveItem
+      operationId: GetDriveItemChildren
+      description: |
+        List the children of the item identified by `item-id` in the drive identified by `drive-id`. The item must exist and be a folder.
+
+        Modeled on the MS Graph list driveItem children endpoint
+        (https://learn.microsoft.com/en-us/graph/api/driveitem-list-children).
+
+        This endpoint also accepts the MS Graph colon-syntax URL forms:
+
+            GET /v1.0/drives/{drive-id}/root:/{path}:/children
+            GET /v1.0/drives/{drive-id}/items/{item-id}:/{path}:/children
+
+        OpenAPI cannot express the colon-delimited path segment, so these URL forms are not represented as separate operations in this specification. The server still accepts them, resolves `:/{path}:` as the parent item, and lists its children.
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668
+          x-ms-docs-key-type: drive
+        - name: item-id
+          in: path
+          description: 'key: id of item'
+          required: true
+          schema:
+            type: string
+          example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
+          x-ms-docs-key-type: item
+      responses:
+        '200':
+          description: Retrieved resource list
+          content:
+            application/json:
+              schema:
+                title: Collection of driveItems
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/driveItem'
+                    maxItems: 100
+                  '@odata.nextLink':
+                    type: string
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   /v1.0/groups:
     get:
       tags:


### PR DESCRIPTION
## Summary

Adds the spec entry for the existing `GET /v1.0/drives/{drive-id}/items/{item-id}/children` endpoint, which has been implemented as `GetDriveItemChildren` (`services/graph/pkg/service/v0/driveitems.go:285`) but had no matching OpenAPI definition. Generated clients (libre-graph-api-go, -typescript-axios, etc.) will pick up a typed method for listing children of a non-root item.

Response shape mirrors the existing `HomeGetChildren` operation: a Collection-of-driveItems object with `value[]` and an optional `@odata.nextLink`.

The description also acknowledges the MS Graph colon-syntax URL forms (`/root:/{path}:/children` and `/items/{item-id}:/{path}:/children`) the server accepts via the path-lookup middleware - OpenAPI cannot express the colon-delimited path segment, so they aren't separate operations but are documented inline.
It's not supported yet, but will be when https://github.com/opencloud-eu/opencloud/pull/2688 is merged.
Changes in this repo usually predate the implementation in the server, so imho it's fine (although fix in the title becomes debatable then ... :))