### PR TITLE
feat: map binary params to io.Reader in Go client

### DIFF
--- a/.woodpecker/build-go.yaml
+++ b/.woodpecker/build-go.yaml
@@ -34,7 +34,8 @@ steps:
         --git-repo-id=libre-graph-api-go
         -g go
         -o libre-graph-api-go
-        --api-name-suffix Api'
+        --api-name-suffix Api
+        --type-mappings=binary=io.Reader,file=io.Reader,File=io.Reader'
       - cp LICENSE libre-graph-api-go/LICENSE
   diff:
     image: *alpine_image


### PR DESCRIPTION
Adds `--type-mappings=binary=io.Reader,file=io.Reader,File=io.Reader` to the Go generator invocation so binary request/response bodies (e.g. `UpdateOwnUserPhotoPut`, `GetOwnUserPhoto`) are emitted as `io.Reader` instead of `*os.File`.

`*os.File` satisfies `io.Reader`, so existing callers compile unchanged. The runtime `setBody` path in the generated client already prefers `io.Reader` over `*os.File`, so behavior is identical at the wire.