### PR TITLE
refactor: map binary params to io.Reader in Go client

### DIFF
--- a/.woodpecker/build-go.yaml
+++ b/.woodpecker/build-go.yaml
@@ -34,7 +34,8 @@ steps:
         --git-repo-id=libre-graph-api-go
         -g go
         -o libre-graph-api-go
-        --api-name-suffix Api'
+        --api-name-suffix Api
+        --type-mappings=binary=io.Reader,file=io.Reader,File=io.Reader'
       - cp LICENSE libre-graph-api-go/LICENSE
   diff:
     image: *alpine_image

--- a/.woodpecker/build-go.yaml
+++ b/.woodpecker/build-go.yaml
@@ -1,7 +1,7 @@
 ---
 variables:
   - &alpine_image 'owncloudci/alpine:latest'
-  - &generator_image 'openapitools/openapi-generator-cli:v7.13.0@sha256:52b4b2bb6129b086b0f12614e98c884d378a84349fa114b07e20515702a793c5'
+  - &generator_image 'openapitools/openapi-generator-cli:v7.23.0@sha256:5ffccd3b0d4ac57eac443e1c9b3e2f2bb7f0a21ffe6c6701f3690d7edc78bf2d'
   - &environment
     HTTP_PROXY:
       from_secret: ci_http_proxy


### PR DESCRIPTION
Adds `--type-mappings=binary=io.Reader,file=io.Reader,File=io.Reader` to the Go generator invocation so binary request/response bodies (e.g. `UpdateOwnUserPhotoPut`, `GetOwnUserPhoto`) are emitted as `io.Reader` instead of `*os.File`.

`*os.File` satisfies `io.Reader`, so existing callers compile unchanged. The runtime `setBody` path in the generated client already prefers `io.Reader` over `*os.File`, so behavior is identical at the wire.

The download path relies on the `*io.Reader` branch added to the shared `decode` helper in [OpenAPITools/openapi-generator#23789](https://github.com/OpenAPITools/openapi-generator/pull/23789), released in [openapi-generator 7.23.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.23.0). The `generator_image` pin in `.woodpecker/build-go.yaml` is bumped from `v7.13.0` to `v7.23.0` accordingly, so `GetOwnUserPhoto` / `GetUserPhoto` decode into `io.Reader` instead of returning `"undefined response type"`.
