### PR TITLE
refactor(ci): adopt wp-git-action 2.2.0 commit-message-from

### DIFF
--- a/.woodpecker/build-cpp-qt.yaml
+++ b/.woodpecker/build-cpp-qt.yaml
@@ -53,7 +53,7 @@ steps:
     when:
       - event: tag
   push_target_repo:
-    image: quay.io/thegeeklab/wp-git-action
+    image: quay.io/thegeeklab/wp-git-action:v2.2.0
     settings:
       path: libre-graph-api-cpp-qt-client
       remote_url: https://github.com/opencloud-eu/libre-graph-api-cpp-qt-client.git
@@ -62,9 +62,7 @@ steps:
         - commit
         - push
       followtags: true
-      message: ${CI_COMMIT_MESSAGE}
-      author_name: ${CI_COMMIT_AUTHOR}
-      author_email: ${CI_COMMIT_AUTHOR_EMAIL}
+      commit-message-from: CI_COMMIT_MESSAGE
       netrc_password:
         from_secret: github_token
       netrc_username:

--- a/.woodpecker/build-go.yaml
+++ b/.woodpecker/build-go.yaml
@@ -53,7 +53,7 @@ steps:
     when:
       - event: tag
   push_target_repo:
-    image: quay.io/thegeeklab/wp-git-action
+    image: quay.io/thegeeklab/wp-git-action:v2.2.0
     settings:
       path: libre-graph-api-go
       remote_url: https://github.com/opencloud-eu/libre-graph-api-go.git
@@ -62,9 +62,7 @@ steps:
         - commit
         - push
       followtags: true
-      message: ${CI_COMMIT_MESSAGE}
-      author_name: ${CI_COMMIT_AUTHOR}
-      author_email: ${CI_COMMIT_AUTHOR_EMAIL}
+      commit-message-from: CI_COMMIT_MESSAGE
       netrc_password:
         from_secret: github_token
       netrc_username:

--- a/.woodpecker/build-php.yaml
+++ b/.woodpecker/build-php.yaml
@@ -53,7 +53,7 @@ steps:
     when:
       - event: tag
   push_target_repo:
-    image: quay.io/thegeeklab/wp-git-action
+    image: quay.io/thegeeklab/wp-git-action:v2.2.0
     settings:
       path: libre-graph-api-php
       remote_url: https://github.com/opencloud-eu/libre-graph-api-php.git
@@ -62,9 +62,7 @@ steps:
         - commit
         - push
       followtags: true
-      message: ${CI_COMMIT_MESSAGE}
-      author_name: ${CI_COMMIT_AUTHOR}
-      author_email: ${CI_COMMIT_AUTHOR_EMAIL}
+      commit-message-from: CI_COMMIT_MESSAGE
       netrc_password:
         from_secret: github_token
       netrc_username:

--- a/.woodpecker/build-typescript-axios.yaml
+++ b/.woodpecker/build-typescript-axios.yaml
@@ -53,7 +53,7 @@ steps:
     when:
       - event: tag
   push_target_repo:
-    image: quay.io/thegeeklab/wp-git-action
+    image: quay.io/thegeeklab/wp-git-action:v2.2.0
     settings:
       path: libre-graph-api-typescript-axios
       remote_url: https://github.com/opencloud-eu/libre-graph-api-typescript-axios.git
@@ -62,9 +62,7 @@ steps:
         - commit
         - push
       followtags: true
-      message: ${CI_COMMIT_MESSAGE}
-      author_name: ${CI_COMMIT_AUTHOR}
-      author_email: ${CI_COMMIT_AUTHOR_EMAIL}
+      commit-message-from: CI_COMMIT_MESSAGE
       netrc_password:
         from_secret: github_token
       netrc_username:


### PR DESCRIPTION
Drops the YAML-substitution workaround for commit metadata and lets [wp-git-action v2.2.0](https://github.com/thegeeklab/wp-git-action/releases/tag/v2.2.0) read the variables from its own environment instead.

- Pin `quay.io/thegeeklab/wp-git-action:v2.2.0`, which introduces `commit-message-from` ([thegeeklab/wp-git-action#357](https://github.com/thegeeklab/wp-git-action/pull/357)).
- Replace `message: ${CI_COMMIT_MESSAGE}` with `commit-message-from: CI_COMMIT_MESSAGE`. The plugin reads the env var at runtime, so the value is no longer spliced into YAML and cannot break on a `:` or `"` in the commit subject.
- Drop the explicit `author_name` and `author_email` settings. The plugin already falls back to `CI_COMMIT_AUTHOR` and `CI_COMMIT_AUTHOR_EMAIL` via its built-in `Sources`.

Applies to all four `.woodpecker/build-*.yaml` pipelines.
