### PR TITLE
feat: add @libre.graph.livePhoto facet to driveItem

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5292,7 +5292,7 @@ components:
           readOnly: true
         vitalityScore:
           type: number
-          format: float
+          format: double
           description: |
             Score between 0 and 1 rating how interesting the motion clip is, used by
             readers to decide whether to autoplay it

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5307,14 +5307,6 @@ components:
             (com.apple.quicktime.live-photo.vitality-scoring-version). Only present on
             the video half. Read-only.
           readOnly: true
-        fullFrameRatePlaybackIntent:
-          type: integer
-          format: int32
-          description: |
-            Whether the video is intended to be played back at full frame rate
-            (com.apple.quicktime.full-frame-rate-playback-intent). Only present on the
-            video half. Read-only.
-          readOnly: true
     geoCoordinates:
       type: object
       readOnly: true

--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4976,6 +4976,9 @@ components:
         '@libre.graph.motionPhoto':
           description: Motion Photo metadata, if the item is a Motion Photo. Read-only.
           $ref: '#/components/schemas/motionPhoto'
+        '@libre.graph.livePhoto':
+          description: Live Photo metadata, if the item is part of an Apple Live Photo. Read-only.
+          $ref: '#/components/schemas/livePhoto'
         '@client.synchronize':
           description: Indicates if the item is synchronized with the underlying storage provider. Read-only.
           type: boolean
@@ -5240,6 +5243,77 @@ components:
             Size in bytes of the embedded video portion of the file. The video is appended at the
             end of the file, so clients can fetch it with a Range request:
             `Range: bytes=<fileSize - videoSize>-`. Read-only.
+          readOnly: true
+    livePhoto:
+      type: object
+      readOnly: true
+      description: |
+        Apple Live Photo metadata. A Live Photo is a pair of files sharing one content
+        identifier: a still image (HEIC or JPEG) and a short QuickTime video. Unlike a
+        Motion Photo, the two parts are separate driveItems. The presence of this facet
+        indicates the item was captured as part of a Live Photo; the counterpart is the
+        driveItem whose livePhoto facet carries the same contentId. Whether an item is
+        the still image or the video half follows from its photo/video facets and MIME
+        type.
+
+        There is no public file format specification; the metadata keys are documented
+        as AVFoundation metadata identifiers:
+        https://developer.apple.com/documentation/avfoundation/avmetadataidentifier
+        On the still image they are stored in the Apple maker note, on the video as
+        com.apple.quicktime.* QuickTime metadata keys.
+      required:
+        - contentId
+      properties:
+        contentId:
+          type: string
+          description: |
+            Identifier (UUID) shared by the still image and the paired video of one
+            Live Photo. Read-only.
+          readOnly: true
+        stillImageTimeUs:
+          type: integer
+          format: int64
+          description: |
+            Time in microseconds within the paired video at which the still image was
+            captured. The value comes from the video file only: it is the presentation
+            time of the com.apple.quicktime.still-image-time timed metadata sample in
+            the QuickTime movie, so it is only present on the video half. The still
+            image carries no reliable equivalent (the Apple maker note tag 0x0017,
+            historically documented as a derivable video index, does not encode a
+            usable time on current iOS versions). If absent, readers should use a
+            timestamp near the middle of the video track. Read-only.
+          readOnly: true
+        auto:
+          type: boolean
+          description: |
+            True if the device decided automatically whether to capture the Live Photo
+            video (com.apple.quicktime.live-photo.auto). Only present on the video half.
+            Read-only.
+          readOnly: true
+        vitalityScore:
+          type: number
+          format: float
+          description: |
+            Score between 0 and 1 rating how interesting the motion clip is, used by
+            readers to decide whether to autoplay it
+            (com.apple.quicktime.live-photo.vitality-score). Only present on the video
+            half. Read-only.
+          readOnly: true
+        vitalityScoringVersion:
+          type: integer
+          format: int64
+          description: |
+            Version of the algorithm that produced vitalityScore
+            (com.apple.quicktime.live-photo.vitality-scoring-version). Only present on
+            the video half. Read-only.
+          readOnly: true
+        fullFrameRatePlaybackIntent:
+          type: integer
+          format: int32
+          description: |
+            Whether the video is intended to be played back at full frame rate
+            (com.apple.quicktime.full-frame-rate-playback-intent). Only present on the
+            video half. Read-only.
           readOnly: true
     geoCoordinates:
       type: object


### PR DESCRIPTION
# Description

## What are Live Photos?

Apple Live Photos are a pair of files: a still image (HEIC or JPEG) and a
short QuickTime video, captured together and linked by a shared content
identifier (a UUID). On the image it is stored in the Apple maker note,
on the video as `com.apple.quicktime.content.identifier`. Unlike Google
Motion Photos (#36) there is no single embedded file, the two halves are
separate driveItems.

There is no public file format specification; the metadata keys are
documented as AVFoundation metadata identifiers:
https://developer.apple.com/documentation/avfoundation/avmetadataidentifier

## What this PR adds

A new read-only `@libre.graph.livePhoto` facet on driveItem, following the
`@libre.graph.motionPhoto` pattern. Facet presence means the item was
captured as part of a Live Photo; the counterpart is the driveItem whose
facet carries the same `contentId`.

| Property | Type | Description |
|---|---|---|
| `contentId` | `string` (required) | UUID shared by both halves, used for pairing. Required: facet presence means the identifier was found. |
| `stillImageTimeUs` | `integer` (int64) | Time in microseconds within the video at which the still was captured. Comes from the video file only; absent until the extraction side supports it (see below). |
| `auto` | `boolean` | Auto Live Photo mode flag (video half only). |
| `vitalityScore` | `number` (double) | 0..1 score of how interesting the clip is, used for autoplay decisions (video half only). |
| `vitalityScoringVersion` | `integer` (int64) | Version of the scoring algorithm (video half only). |

## Example response

```json
{
  "@libre.graph.livePhoto": {
    "contentId": "CD28D161-D5EC-4CDE-8B60-DACCC1363B6B",
    "stillImageTimeUs": 1233333,
    "auto": true,
    "vitalityScore": 0.9398496,
    "vitalityScoringVersion": 4
  }
}
```

Validated with openapi-generator-cli v7.13.0 (`validate` plus a go client
generation smoke test; the generated model and driveItem wiring look as
expected).

Metadata extraction prerequisites on the server side: the video-side keys
are covered by https://github.com/apache/tika/pull/2935, the image-side
Live Photo video index additionally needs
https://github.com/drewnoakes/metadata-extractor/pull/739 (tracked in
https://issues.apache.org/jira/browse/TIKA-4776). `stillImageTimeUs` is
specified now but will stay absent until the extraction side can parse
the `com.apple.quicktime.still-image-time` timed metadata track (mebx)
of the video. The image side offers no reliable source: the Apple maker
note tag 0x0017, historically documented as a derivable video index,
does not encode a usable time on current iOS versions.
