### PR TITLE
ci: fix wp-git-action image tag

### DIFF
--- a/.woodpecker/build-cpp-qt.yaml
+++ b/.woodpecker/build-cpp-qt.yaml
@@ -53,7 +53,7 @@ steps:
     when:
       - event: tag
   push_target_repo:
-    image: quay.io/thegeeklab/wp-git-action:v2.2.0
+    image: quay.io/thegeeklab/wp-git-action:2.2.0
     settings:
       path: libre-graph-api-cpp-qt-client
       remote_url: https://github.com/opencloud-eu/libre-graph-api-cpp-qt-client.git

--- a/.woodpecker/build-go.yaml
+++ b/.woodpecker/build-go.yaml
@@ -54,7 +54,7 @@ steps:
     when:
       - event: tag
   push_target_repo:
-    image: quay.io/thegeeklab/wp-git-action:v2.2.0
+    image: quay.io/thegeeklab/wp-git-action:2.2.0
     settings:
       path: libre-graph-api-go
       remote_url: https://github.com/opencloud-eu/libre-graph-api-go.git

--- a/.woodpecker/build-php.yaml
+++ b/.woodpecker/build-php.yaml
@@ -53,7 +53,7 @@ steps:
     when:
       - event: tag
   push_target_repo:
-    image: quay.io/thegeeklab/wp-git-action:v2.2.0
+    image: quay.io/thegeeklab/wp-git-action:2.2.0
     settings:
       path: libre-graph-api-php
       remote_url: https://github.com/opencloud-eu/libre-graph-api-php.git

--- a/.woodpecker/build-typescript-axios.yaml
+++ b/.woodpecker/build-typescript-axios.yaml
@@ -53,7 +53,7 @@ steps:
     when:
       - event: tag
   push_target_repo:
-    image: quay.io/thegeeklab/wp-git-action:v2.2.0
+    image: quay.io/thegeeklab/wp-git-action:2.2.0
     settings:
       path: libre-graph-api-typescript-axios
       remote_url: https://github.com/opencloud-eu/libre-graph-api-typescript-axios.git


### PR DESCRIPTION
The v-prefixed tags of `quay.io/thegeeklab/wp-git-action` no longer exist on quay.io (republished without the prefix), which broke the push step of all generator pipelines, so the client repos stopped receiving updates. Use the tag without the prefix.