### PR TITLE
feat: add GET /drives/{drive-id}/root/children

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -2234,6 +2234,40 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/v1.0/drives/{drive-id}/root/children':
+    get:
+      tags:
+        - drives.root.children
+      summary: List children of the root of a drive
+      operationId: GetRootChildren
+      parameters:
+        - name: drive-id
+          in: path
+          description: 'key: id of drive'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: drive
+        - $ref: '#/components/parameters/driveItemSelect'
+      responses:
+        '200':
+          description: Retrieved resource list
+          content:
+            application/json:
+              schema:
+                title: Collection of driveItems
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/driveItem'
+                    maxItems: 100
+                  '@odata.nextLink':
+                    type: string
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   '/v1.0/drives/{drive-id}/items/{item-id}/children':
     get:
       tags:


### PR DESCRIPTION
Adds `GET /drives/{drive-id}/root/children` to list the root children of an arbitrary drive.

Today this only exists for `/me/drive/root/children` (`HomeGetChildren`); for other drives you have to resolve the root item and call `/drives/{drive-id}/items/{item-id}/children`. MS Graph has the drive-scoped shortcut, libregraph was missing it. Mirrors `HomeGetChildren`.

MS Graph reference: https://learn.microsoft.com/en-us/graph/api/driveitem-list-children
