### PR TITLE
Document GET /v1.0/users/{user-id}/drive

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -3117,6 +3117,35 @@ paths:
         default:
           $ref: '#/components/responses/error'
       x-ms-docs-operation-type: operation
+  '/v1.0/users/{user-id}/drive':
+    get:
+      tags:
+        - user.drive
+      summary: Get a user's drive.
+      operationId: GetUserDrive
+      description: |
+        Get the personal Drive of the user identified by `user-id`.
+
+        Modeled on the MS Graph get drive endpoint
+        (https://learn.microsoft.com/en-us/graph/api/drive-get).
+      parameters:
+        - name: user-id
+          in: path
+          description: 'key: id or name of user'
+          required: true
+          schema:
+            type: string
+          x-ms-docs-key-type: user
+      responses:
+        '200':
+          description: Retrieved drive
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/drive'
+        default:
+          $ref: '#/components/responses/error'
+      x-ms-docs-operation-type: operation
   '/v1.0/users/{user-id}/exportPersonalData':
     post:
       tags:


### PR DESCRIPTION
Documents `GET /v1.0/users/{user-id}/drive` (`GetUserDrive`), which the OpenCloud graph service already serves but the spec never documented. Reuses the existing `drive` schema.

The server already implements the endpoint, but so far it only accepts the user's opaque **id** in the `{user-id}` segment, not a name, unlike the other user-addressed endpoints (`GetUser` etc.) which resolve id-or-name. MS Graph addresses this endpoint by id **or** userPrincipalName as well (see [Get drive](https://learn.microsoft.com/en-us/graph/api/drive-get): `GET /users/{idOrUserPrincipalName}/drive`). That username resolution is being added in opencloud-eu/opencloud#3243 so the endpoint is consistent with its siblings and with MS Graph; this spec therefore documents the `{user-id}` parameter as "id or name of user". The two changes go together.