### PR TITLE
feat: wire driveItemSelect to GetDriveItemChildren

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -2308,6 +2308,7 @@ paths:
             type: string
           example: a0ca6a90-a365-4782-871e-d44447bbc668$a0ca6a90-a365-4782-871e-d44447bbc668!share-id
           x-ms-docs-key-type: item
+        - $ref: '#/components/parameters/driveItemSelect'
       responses:
         '200':
           description: Retrieved resource list


### PR DESCRIPTION
Attaches the existing `driveItemSelect` parameter to `GetDriveItemChildren`, so generated clients get a typed `$select` on children listings.

The server already evaluates `$select` in my pr (opencloud-eu/opencloud#3248 populates `@microsoft.graph.downloadUrl` on children); this closes the remaining spec gap.