### PR TITLE
feat: add @libre.graph.shareTypes to driveItem

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -5243,6 +5243,25 @@ components:
           items:
             type: string
           readOnly: true
+        '@libre.graph.shareTypes':
+          type: array
+          description: |
+            The types of shares existing on this item, aggregated over all of
+            its grants. Absent or empty if the item is not shared.
+
+            This is a summary of the item's `permissions` collection. For the
+            full grants use the permissions endpoints, for the caller's own
+            capabilities use `@libre.graph.permissions.actions.allowedValues`.
+
+            Only returned when explicitly requested via `$select`.
+          items:
+            type: string
+            enum:
+              - user
+              - group
+              - link
+              - remote
+          readOnly: true
     sharingLinkType:
       type: string
       enum: [ internal, view, upload, edit, createOnly, blocksDownload ]


### PR DESCRIPTION
Adds a read-only `@libre.graph.shareTypes` annotation to driveItem, listing the types of shares existing on an item (`user`, `group`, `link`, `remote`). Lets listings render share indicators without expanding permissions. Only returned when requested via `$select`.

Replaces `oc:share-types` from WebDAV PROPFIND for Graph listings. Server side can derive `user` and `group` from the storage grants, same as ocdav does today.