### PR TITLE
feat: add @UI.extension on drive

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -4729,6 +4729,12 @@ components:
           type: boolean
           description: Indicates whether the drive has items in the trash. Read-only.
           readOnly: true
+        '@UI.extension':
+          type: string
+          description: |
+            Specifier for the web client that a drive has an associated extension
+            that could potentially be opened by a specific web app (like a file
+            extension).
     driveRecipient:
       type: object
       description: |


### PR DESCRIPTION
This property is a pointer for the web client that a drive has an associated extension that could potentially be opened by a specific web app, if there is one that claims it (e.g. a drive with `@UI.extension: 'vault'` can be opened with the `rclone-crypt` app if enabled).

It's supposed to be returned with every drive listing and writable via `CreateDrive` and `UpdateDrive`.

refs https://github.com/opencloud-eu/web/issues/3029#issuecomment-5200922893