### PR TITLE
fix(spec): driveItem creation returns 201 Created

### DIFF
--- a/api/openapi-spec/v1.0.yaml
+++ b/api/openapi-spec/v1.0.yaml
@@ -535,8 +535,8 @@ paths:
                   remoteItem:
                     id: a-storage-provider-id$a-space-id!a-node-id
       responses:
-        '200':
-          description: Response
+        '201':
+          description: The created DriveItem.
           content:
             application/json:
               schema:
@@ -1416,7 +1416,7 @@ paths:
             schema:
               $ref: '#/components/schemas/driveItem'
       responses:
-        '200':
+        '201':
           description: The created DriveItem.
           content:
             application/json:


### PR DESCRIPTION
MS Graph returns 201 Created here (https://learn.microsoft.com/en-us/graph/api/driveitem-post-children?view=graph-rest-1.0#response), the server does too (opencloud-eu/opencloud#3116).